### PR TITLE
Add postcss-loader to fix the version and avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nuxtjs/storybook": "^4.0.3",
     "core-js": "3",
     "nodemon": "^2.0.6",
+    "postcss-loader": "~3.0.0",
     "sass": "^1.34.1",
     "sass-loader": "^10.1.0",
     "slice-machine-ui": "^0.1.0-beta.2",


### PR DESCRIPTION
Hello, I add the `post-css` as dev dependencies to avoid config conflict. 

I don't found any more elegant way to fix this problem on a long term by now. 
